### PR TITLE
Rückgabefehler behoben

### DIFF
--- a/server/routes/image.js
+++ b/server/routes/image.js
@@ -11,7 +11,7 @@ router.post('/', (req, res, next) => {
     });
     if (fs.existsSync("./demo/" + file + ".jpg")) {
         res.status(203);
-        res.json(result);
+        res.json({filename: file});
     }
 });
 router.get('/:id', (req, res, next) => {


### PR DESCRIPTION
Da das db Team nicht alle hochgeladenen bilder in eine Tabelle abspeichern will. Wurde vergessen auch das result abzuändern